### PR TITLE
Aacn500 remove halfti

### DIFF
--- a/core/src/com/muscovy/game/Collidable.java
+++ b/core/src/com/muscovy/game/Collidable.java
@@ -95,7 +95,7 @@ public abstract class Collidable extends OnscreenDrawable {
 			yTiles = DungeonRoom.FLOOR_HEIGHT_IN_TILES - heightTiles;
 		}
 		this.yTiles = yTiles;
-		setY((yTiles * (MuscovyGame.TILE_SIZE + 100)) + MuscovyGame.TILE_SIZE);
+		setY((yTiles * (MuscovyGame.TILE_SIZE + 1)) + MuscovyGame.TILE_SIZE);
 	}
 
 

--- a/core/src/com/muscovy/game/Collidable.java
+++ b/core/src/com/muscovy/game/Collidable.java
@@ -79,11 +79,11 @@ public abstract class Collidable extends OnscreenDrawable {
 		/**
 		 * Use this when setting something in the playable space to make sure it is on the grid.
 		 */
-		if (xTiles > (DungeonRoom.FLOOR_WIDTH_IN_HALF_TILES - widthTiles)) {
-			xTiles = DungeonRoom.FLOOR_WIDTH_IN_HALF_TILES - widthTiles;
+		if (xTiles > (DungeonRoom.FLOOR_WIDTH_IN_TILES - widthTiles)) {
+			xTiles = DungeonRoom.FLOOR_WIDTH_IN_TILES - widthTiles;
 		}
 		this.xTiles = xTiles;
-		setX((xTiles * (MuscovyGame.HALF_TILE_SIZE + 100)) + MuscovyGame.TILE_SIZE);
+		setX((xTiles * (MuscovyGame.TILE_SIZE + 1)) + MuscovyGame.TILE_SIZE);
 	}
 
 
@@ -91,11 +91,11 @@ public abstract class Collidable extends OnscreenDrawable {
 		/**
 		 * Use this when setting something in the playable space to make sure it is on the grid.
 		 */
-		if (yTiles > (DungeonRoom.FLOOR_HEIGHT_IN_HALF_TILES - heightTiles)) {
-			yTiles = DungeonRoom.FLOOR_HEIGHT_IN_HALF_TILES - heightTiles;
+		if (yTiles > (DungeonRoom.FLOOR_HEIGHT_IN_TILES - heightTiles)) {
+			yTiles = DungeonRoom.FLOOR_HEIGHT_IN_TILES - heightTiles;
 		}
 		this.yTiles = yTiles;
-		setY((yTiles * (MuscovyGame.HALF_TILE_SIZE + 100)) + MuscovyGame.TILE_SIZE);
+		setY((yTiles * (MuscovyGame.TILE_SIZE + 100)) + MuscovyGame.TILE_SIZE);
 	}
 
 
@@ -151,8 +151,8 @@ public abstract class Collidable extends OnscreenDrawable {
 		float y = getY();
 		float width = getWidth();
 		float height = getHeight();
-		widthTiles = (int) Collidable.floorDiv((long) width, 32) + 1;
-		heightTiles = (int) Collidable.floorDiv((long) height, 32) + 1;
+		widthTiles = (int) Collidable.floorDiv((long) width, MuscovyGame.TILE_SIZE) + 1;
+		heightTiles = (int) Collidable.floorDiv((long) height, MuscovyGame.TILE_SIZE) + 1;
 		circleHitbox = new Circle(x + (width / 2), y + (height / 2) + hitboxYOffset, width / 2);
 		rectangleHitbox = new Rectangle(x, y, width, height);
 	}

--- a/core/src/com/muscovy/game/Collidable.java
+++ b/core/src/com/muscovy/game/Collidable.java
@@ -9,8 +9,9 @@ import com.badlogic.gdx.math.Vector2;
 
 /**
  * Created by SeldomBucket on 05-Jan-16.
+ * Class in inherited by all entities in game that can be collided with.
  * 
- * Players and enemies both exist on a 64x64 tile. 
+ * All inheritors of Collidable exist on a 64x64 tile. 
  */
 public abstract class Collidable extends OnscreenDrawable {
 	private Circle circleHitbox;
@@ -18,8 +19,6 @@ public abstract class Collidable extends OnscreenDrawable {
 	// Offset from centre of collidable: offset of 6 means centre of circle hitbox is 6 pixels above centre of
 	// collidable
 	private float hitboxYOffset = 0;
-	private int xTiles;
-	private int yTiles;
 	private int widthTiles;
 	private int heightTiles;
 
@@ -59,16 +58,6 @@ public abstract class Collidable extends OnscreenDrawable {
 	}
 
 
-	public int getXTiles() {
-		return xTiles;
-	}
-
-
-	public int getYTiles() {
-		return yTiles;
-	}
-
-
 	// TODO: Should setX/YTiles use modulo and constants for world width/height
 
 	/**
@@ -82,7 +71,6 @@ public abstract class Collidable extends OnscreenDrawable {
 		if (xTiles > (DungeonRoom.FLOOR_WIDTH_IN_TILES - widthTiles)) {
 			xTiles = DungeonRoom.FLOOR_WIDTH_IN_TILES - widthTiles;
 		}
-		this.xTiles = xTiles;
 		setX((xTiles * (MuscovyGame.TILE_SIZE + 1)) + MuscovyGame.TILE_SIZE);
 	}
 
@@ -94,7 +82,6 @@ public abstract class Collidable extends OnscreenDrawable {
 		if (yTiles > (DungeonRoom.FLOOR_HEIGHT_IN_TILES - heightTiles)) {
 			yTiles = DungeonRoom.FLOOR_HEIGHT_IN_TILES - heightTiles;
 		}
-		this.yTiles = yTiles;
 		setY((yTiles * (MuscovyGame.TILE_SIZE + 1)) + MuscovyGame.TILE_SIZE);
 	}
 

--- a/core/src/com/muscovy/game/DungeonRoom.java
+++ b/core/src/com/muscovy/game/DungeonRoom.java
@@ -170,7 +170,7 @@ public class DungeonRoom extends OnscreenDrawable {
 			int[][] tileArray = new int[roomHeight][roomWidth];
 
 			int roomChoiceCount = 10;
-			int chosenLayout = 5;
+			int chosenLayout = rand.nextInt(roomChoiceCount);
 
 			final int emptyTile = 0;
 			final int nonDamagingObstacle = 1;

--- a/core/src/com/muscovy/game/DungeonRoom.java
+++ b/core/src/com/muscovy/game/DungeonRoom.java
@@ -51,8 +51,8 @@ public class DungeonRoom extends OnscreenDrawable {
 	private TextureMap textureMap;
 	
 	
-	public static final int FLOOR_HEIGHT_IN_HALF_TILES = 20;
-	public static final int FLOOR_WIDTH_IN_HALF_TILES = 36;
+	public static final int FLOOR_HEIGHT_IN_TILES = 10;
+	public static final int FLOOR_WIDTH_IN_TILES = 18;
 	
 	public DungeonRoom(TextureMap textureMap) {
 		this.textureMap = textureMap;
@@ -170,7 +170,7 @@ public class DungeonRoom extends OnscreenDrawable {
 			int[][] tileArray = new int[roomHeight][roomWidth];
 
 			int roomChoiceCount = 10;
-			int chosenLayout = rand.nextInt(roomChoiceCount);
+			int chosenLayout = 5;
 
 			final int emptyTile = 0;
 			final int nonDamagingObstacle = 1;
@@ -310,21 +310,21 @@ public class DungeonRoom extends OnscreenDrawable {
 					case emptyTile:
 						break;
 					case nonDamagingObstacle:
-						createNonDamagingObstacle(2 * col, 2 * row);
+						createNonDamagingObstacle(col, row);
 						break;
 					case damagingObstacle:
-						createDamagingObstacle(2 * col, 2 * row);
+						createDamagingObstacle(col, row);
 						break;
 					case maybeDamagingObstacle:
 						if (obstacleType3NonDamaging) {
-							createNonDamagingObstacle(2 * col, 2 * row);
+							createNonDamagingObstacle(col, row);
 						} else if (!obstacleType3NonDamaging) {
-							createDamagingObstacle(2 * col, 2 * row);
+							createDamagingObstacle(col, row);
 						}
 						break;
 					case maybeEnemy:
 						if (rand.nextInt(5) < 3) {
-							createRandomEnemy(2 * col, 2 * row);
+							createRandomEnemy(col, row);
 						}
 						break;
 					default:

--- a/core/src/com/muscovy/game/DungeonRoom.java
+++ b/core/src/com/muscovy/game/DungeonRoom.java
@@ -23,9 +23,6 @@ public class DungeonRoom extends OnscreenDrawable {
 	 * entered. Room is generated using a 2d array (explained in more detail further down) There are 2 sets of
 	 * walls, one for the enemies and player to collide with, and one for the projectile to collide with so it looks
 	 * like they break halfway up the wall, and have some height associated with them.
-	 * 
-	 * The room is made up of 32x32 'half tiles' (used in map gen). The number of tiles in each direction is stored in constants
-	 * in {@link DungeonRoom.floorWidthInHalfTiles} & {@link DungeonRoom.floorHeightInHalfTiles}.  
 	 */
 	private ArrayList<Obstacle> obstacleList;
 	private ArrayList<Enemy> enemyList;

--- a/core/src/com/muscovy/game/DungeonRoom.java
+++ b/core/src/com/muscovy/game/DungeonRoom.java
@@ -339,8 +339,8 @@ public class DungeonRoom extends OnscreenDrawable {
 			bossSprite = new Sprite(
 					textureMap.getTextureOrLoadFile("accommodationAssets/accommodationBoss.png"));
 			bossEnemy = new Enemy(textureMap, bossSprite);
-			bossEnemy.setXTiles((int) ((36 / 2) - (bossEnemy.getWidth() / 64)));
-			bossEnemy.setYTiles((int) ((18 / 2) - (bossEnemy.getHeight() / 64)));
+			bossEnemy.setXTiles((int) ((FLOOR_WIDTH_IN_TILES / 2) - (bossEnemy.getWidth() / MuscovyGame.TILE_SIZE / 2)));
+			bossEnemy.setYTiles((int) ((FLOOR_HEIGHT_IN_TILES / 2) - (bossEnemy.getHeight() / MuscovyGame.TILE_SIZE / 2)));
 			bossEnemy.setAttackType(AttackType.BOTH);
 			bossEnemy.setMovementType(MovementType.FOLLOW);
 			// bossEnemy.setMaxVelocity(100);

--- a/core/src/com/muscovy/game/MuscovyGame.java
+++ b/core/src/com/muscovy/game/MuscovyGame.java
@@ -55,8 +55,8 @@ public class MuscovyGame extends ApplicationAdapter implements ApplicationListen
 
 	public static final float WINDOW_WIDTH = 1280;
 	public static final float WINDOW_HEIGHT = 816; // 960;
-	public static final float TILE_SIZE = 64;
-	public static final float HALF_TILE_SIZE = MuscovyGame.TILE_SIZE / 2; // 32
+	public static final int TILE_SIZE = 64;
+	//public static final float HALF_TILE_SIZE = MuscovyGame.TILE_SIZE / 2; // 32
 	public static final float WORLD_HEIGHT = 768; // WINDOW_HEIGHT - TOP_GUI_SIZE; // 768
 	public static final float TOP_GUI_SIZE = MuscovyGame.WINDOW_HEIGHT - MuscovyGame.WORLD_HEIGHT; // 192; //
 													// TILE_SIZE * 3

--- a/core/src/com/muscovy/game/PlayerCharacter.java
+++ b/core/src/com/muscovy/game/PlayerCharacter.java
@@ -531,7 +531,8 @@ public class PlayerCharacter extends Collidable {
 		 * directly to the entity manager
 		 */
 		float x = ((getX() + (getWidth() / 2)) - 8);
-		float y = ((getY() + getHeight()) - 32);
+		// TODO: This should get player's height, not tile size
+		float y = ((getY() + getHeight()) - MuscovyGame.TILE_SIZE/2);
 
 		Vector2 position = new Vector2(x, y);
 		Vector2 direction = shotDirection.cpy();


### PR DESCRIPTION
This branch should remove (almost) all references to "half tiles" (32x32 tiles). Everything should now be in terms of 64x64 tiles for consistency.
